### PR TITLE
refactor(component): Adds isStandardZipCode()

### DIFF
--- a/src/common/isStandardZipCode/isStandardZipCode.js
+++ b/src/common/isStandardZipCode/isStandardZipCode.js
@@ -1,0 +1,9 @@
+import { isUndefined, isNull } from './../../utils';
+
+const isStandardZipCode = zipCode => (
+  !isUndefined(zipCode) &&
+  !isNull(zipCode) &&
+  /^\d{5}(-\d{4})?$/.test(zipCode)
+);
+
+export default isStandardZipCode;

--- a/src/common/isStandardZipCode/isStandardZipCode.spec.js
+++ b/src/common/isStandardZipCode/isStandardZipCode.spec.js
@@ -1,0 +1,34 @@
+import { assert } from 'chai';
+import isStandardZipCode from './isStandardZipCode';
+
+describe('Regexer', () => {
+  describe('isStandardZipCode()', () => {
+    it('should return true when passes \'02140\'', () => {
+      assert.equal(isStandardZipCode('02140'), true);
+    });
+    it('should return true when passes 45546', () => {
+      assert.equal(isStandardZipCode(45546), true);
+    });
+    it('should return true when passes \'12345-6789\'', () => {
+      assert.equal(isStandardZipCode('12345-6789'), true);
+    });
+    it('should return false when passes \'12345-678932\'', () => {
+      assert.equal(isStandardZipCode('12345-678932'), false);
+    });
+    it('should return false when passes \'12345 6789\'', () => {
+      assert.equal(isStandardZipCode('12345 6789'), false);
+    });
+    it('should return false when passes \'98121-\'', () => {
+      assert.equal(isStandardZipCode('98121-'), false);
+    });
+    it('should return false when passes \'\'', () => {
+      assert.equal(isStandardZipCode(''), false);
+    });
+    it('should return false when passes \'?\'', () => {
+      assert.equal(isStandardZipCode('?'), false);
+    });
+    it('should return false when passes null', () => {
+      assert.equal(isStandardZipCode(null), false);
+    });
+  });
+});


### PR DESCRIPTION
Adds isStandardZipCode() common function to check whether or not a candidate string or a number is a
valid US postal zip code